### PR TITLE
6.3 / API 8

### DIFF
--- a/Redirect/ExtensionMethods.cs
+++ b/Redirect/ExtensionMethods.cs
@@ -70,7 +70,7 @@ namespace Redirect {
             unsafe {
                 var player_ptr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)player.Address;
                 var target_ptr = (FFXIVClientStructs.FFXIV.Client.Game.Object.GameObject*)target.Address;
-                err = ActionManager.fpGetActionInRangeOrLoS(a.RowId, player_ptr, target_ptr);
+                err = ActionManager.MemberFunctionPointers.GetActionInRangeOrLoS(a.RowId, player_ptr, target_ptr);
             }
 
             // 0 success, 562 no LOS, 566 range, 565 not facing

--- a/Redirect/Redirect.csproj
+++ b/Redirect/Redirect.csproj
@@ -3,14 +3,14 @@
   <PropertyGroup>
     <Authors></Authors>
     <Company></Company>
-    <Version>1.2.1.1</Version>
+    <Version>1.2.1.2</Version>
     <Description>Action target switching plugin for Dalamud.</Description>
     <Copyright>Cair © 2021 - 2022</Copyright>
     <PackageProjectUrl>https://github.com/cairthenn/Redirect</PackageProjectUrl>
   </PropertyGroup>
 
   <PropertyGroup>
-    <TargetFramework>net6.0-windows</TargetFramework>
+    <TargetFramework>net7.0-windows</TargetFramework>
     <Platforms>x64</Platforms>
     <Nullable>enable</Nullable>
     <LangVersion>latest</LangVersion>
@@ -18,12 +18,13 @@
     <ProduceReferenceAssembly>false</ProduceReferenceAssembly>
     <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
 	<RestorePackagesWithLockFile>true</RestorePackagesWithLockFile>
-    <OutputPath>C:\Users\Mark\AppData\Roaming\XIVLauncher\devPlugins\Redirect\</OutputPath>
   </PropertyGroup>
 
   <PropertyGroup>
     <DalamudLibPath>$(appdata)\XIVLauncher\addon\Hooks\dev\</DalamudLibPath>
     <AssemblyVersion></AssemblyVersion>
+    <PackageOutputPath />
+    <GeneratePackageOnBuild>False</GeneratePackageOnBuild>
   </PropertyGroup>
 
   <ItemGroup>
@@ -37,7 +38,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="DalamudPackager" Version="2.1.8" />
+    <PackageReference Include="DalamudPackager" Version="2.1.10" />
     <Reference Include="FFXIVClientStructs">
       <HintPath>$(DalamudLibPath)FFXIVClientStructs.dll</HintPath>
       <Private>false</Private>

--- a/Redirect/Redirect.json
+++ b/Redirect/Redirect.json
@@ -10,5 +10,5 @@
   "Name": "Redirect",
   "Punchline": "Change where your actions are going, queue macros, queue sprint, and queue potions!",
   "RepoUrl": "https://github.com/cairthenn/Redirect",
-  "DalamudApiLevel": 7
+  "DalamudApiLevel": 8
 }

--- a/Redirect/packages.lock.json
+++ b/Redirect/packages.lock.json
@@ -1,12 +1,12 @@
 {
   "version": 1,
   "dependencies": {
-    "net6.0-windows7.0": {
+    "net7.0-windows7.0": {
       "DalamudPackager": {
         "type": "Direct",
-        "requested": "[2.1.8, )",
-        "resolved": "2.1.8",
-        "contentHash": "YqagNXs9InxmqkXzq7kLveImxnodkBEicAhydMXVp7dFjC7xb76U6zGgAax4/BWIWfZeWzr5DJyQSev31kj81A=="
+        "requested": "[2.1.10, )",
+        "resolved": "2.1.10",
+        "contentHash": "S6NrvvOnLgT4GDdgwuKVJjbFo+8ZEj+JsEYk9ojjOR/MMfv1dIFpT8aRJQfI24rtDcw1uF+GnSSMN4WW1yt7fw=="
       }
     }
   }


### PR DESCRIPTION
Changes:
- Updates FFXIVClientStructs
- Update ActionResourceSig
- Remove devPlugins for output dir as it's deprecated.

Goal:
- Initial support of 6.3 and API 8 with the new FFXIVClientStructs. Does not attempt to improve or clean up existing code aside from the minimal edits needed.