### PR TITLE
Override redirection using /ac with placeholder

### DIFF
--- a/Redirect/GameHooks.cs
+++ b/Redirect/GameHooks.cs
@@ -171,12 +171,12 @@ namespace Redirect {
             }
         }
 
-        public GameObject? ResolveTarget(string target) {
-            return target switch {
+        public GameObject? ResolveTarget(string targetOption, ulong originalTarget) {
+            return targetOption switch {
                 "UI Mouseover" => CurrentUIMouseover,
                 "Model Mouseover" => TargetManager.MouseOverTarget,
                 "Self" => Services.ClientState.LocalPlayer,
-                "Target" => TargetManager.Target,
+                "Target" => Services.ObjectTable.SearchById(originalTarget) ?? TargetManager.Target,
                 "Focus" => TargetManager.FocusTarget,
                 "Target of Target" => TargetManager.Target is { } ? TargetManager.Target.TargetObject : null,
                 "Soft Target" => TargetManager.SoftTarget,
@@ -257,7 +257,7 @@ namespace Redirect {
                         }
                     }
                     else {
-                        GameObject? nt = ResolveTarget(t);
+                        GameObject? nt = ResolveTarget(t, target);
                         if (nt is not null) {
                             bool ok = adjusted_row.TargetInRangeAndLOS(nt, out var err);
                             bool tt_ok = adjusted_row.TargetTypeValid(nt);


### PR DESCRIPTION
When a redirection is configured as:
```
1. Target
2. Target of Target
```
It's not possible to have a macro to use the action on a specific predefined target, e.g.
```
/ac Regen <me>
```
When an enemy is targeted, the "Target of Target" rule is used even when `<me>` is specified.

This change modifies the "Target" rule behavior such that when a placeholder is specified in `/ac` (e.g. `<me>`), the rule resolve to the placeholder instead of the actual current target.